### PR TITLE
fix paths for shopware composer_install setup

### DIFF
--- a/Frontend/HeidelGateway/Bootstrap.php
+++ b/Frontend/HeidelGateway/Bootstrap.php
@@ -56,7 +56,7 @@ class Shopware_Plugins_Frontend_HeidelGateway_Bootstrap extends Shopware_Compone
 	public function getInfo(){
 		$prefix 	= substr($_SERVER['SCRIPT_FILENAME'], 0, strrpos($_SERVER['SCRIPT_FILENAME'], '/'));
 //		$hp_logo 	= base64_encode(file_get_contents(dirname(__FILE__) . '/img/heidelpay.png'));
-		$hp_logo 	= dirname(__FILE__) . '/img/heidelpay.png';
+		$hp_logo 	= substr(realpath(dirname(__FILE__)), strlen(Shopware()->DocPath())-1) . '/img/heidelpay.png';
 		return array(
 				'version' => $this->getVersion(),
 				'autor' => 'heidelpay GmbH (SP)',
@@ -1952,7 +1952,7 @@ class Shopware_Plugins_Frontend_HeidelGateway_Bootstrap extends Shopware_Compone
 		// SSL Problem?! http://forum.shopware.com/allgemein-f25/nach-update-auf-4-3-1-resource-shop-not-found-klarna-t22933.html
         if($request->getModuleName() == 'frontend'){
             $realpath 		= realpath(dirname(__FILE__));
-			$pluginPath 	= substr($realpath,strpos($realpath, '/engine'));
+			$pluginPath 	= substr($realpath, strlen(Shopware()->DocPath())-1);
 			$basepath		= Shopware()->System()->sCONFIG['sBASEPATH'];
 			$shopPath		= substr($basepath,strpos($basepath, '/'));
 

--- a/Frontend/HeidelGateway/Controllers/Frontend/PaymentHgw.php
+++ b/Frontend/HeidelGateway/Controllers/Frontend/PaymentHgw.php
@@ -118,7 +118,7 @@ class Shopware_Controllers_Frontend_PaymentHgw extends Shopware_Controllers_Fron
 			$ppd_crit['CRITERION.SESS'] = $user['additional']['user']['sessionID'];
 
 			$realpath 		= realpath(dirname(__FILE__));
-			$start 			= strpos($realpath, '/engine');
+			$start 			= strlen(Shopware()->DocPath())-1;
 			$ende 			= strpos($realpath, '/Controllers');
 			$len = $ende - $start;
 			$pluginPath 	= substr($realpath,$start,$len);


### PR DESCRIPTION
The Plugin currently doesn't work when using the [composer-setup](https://github.com/shopware/composer-project) structure of shopware.
Paths are currently constructed with an error-prone `strpos` comparison which only works if the Plugin is installed in `/engine/Plugins/...`. The structure of [composer-setup](https://github.com/shopware/composer-project) uses `/Plugins` so the `strpos` comparison fails and ends in an absolute path for .js and image files.
This PR rewrites those definitions without requiring a static `/engine` path making it compatible to any folder structure.